### PR TITLE
[FIX] docker-compose: Unset variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - PGUSER=odoo
       - PGPASSWORD=odoo
       #- MARABUNTA_FORCE_VERSION=setup
+      - PLATFORM=
       - RUNNING_ENV=template
       - ODOO_DBFILTER=
       - ODOO_LIST_DB=True


### PR DESCRIPTION
Attempted a docker-compose up and encountered this error: 
app_1  | Configure Rclone
app_1  | 2021/06/28 23:23:13 Failed to process templates: template: rclone.conf.tmpl:1:25: executing "rclone.conf.tmpl" at <.Env.PLATFORM>: invalid value; expected string.
odoo-template_app_1 exited with code 123